### PR TITLE
Support for home, mobile or both phone numbers

### DIFF
--- a/Config/config.xml
+++ b/Config/config.xml
@@ -4,6 +4,16 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://thelia.net/schema/dic/config http://thelia.net/schema/dic/config/thelia-1.0.xsd">
 
+    <forms>
+        <form name="forcephone_configuration" class="ForcePhone\Form\ConfigForm" />
+    </forms>
+
+    <hooks>
+        <hook id="forcephone.configuration.hook" class="ForcePhone\Hook\HookManager" scope="request">
+            <tag name="hook.event_listener" event="module.configuration" type="back" method="onModuleConfigure" />
+        </hook>
+    </hooks>
+
     <services>
         <service id="forcephone.services" class="ForcePhone\EventListeners\ForcePhoneEventListener" scope="request">
             <argument id="request" type="service"/>

--- a/Config/module.xml
+++ b/Config/module.xml
@@ -4,20 +4,26 @@
         xsi:schemaLocation="http://thelia.net/schema/dic/module http://thelia.net/schema/dic/module/module-2_2.xsd">
     <fullnamespace>ForcePhone\ForcePhone</fullnamespace>
     <descriptive locale="en_US">
-        <title>Set the phone input mandatory for the customer</title>
+        <title>Require the customer to enter its home phone number, mobile phone number or both</title>
     </descriptive>
     <descriptive locale="fr_FR">
-        <title>Oblige le client à laisser un numéro de téléphone</title>
+        <title>Oblige le client à laisser un numéro de téléphone fixe, mobile ou les deux</title>
     </descriptive>
     <languages>
         <language>en_US</language>
         <language>fr_FR</language>
     </languages>
-    <version>1.0</version>
+    <version>1.1</version>
     <authors>
         <author>
             <name>Etienne Perriere</name>
             <email>eperriere@openstudio.fr</email>
+        </author>
+        <author>
+            <name>Franck Allimant</name>
+            <company>CQFDev</company>
+            <email>franck@cqfdev.fr</email>
+            <website>www.cqfdev.fr</website>
         </author>
     </authors>
     <type>classic</type>

--- a/Config/routing.xml
+++ b/Config/routing.xml
@@ -4,4 +4,7 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
 
+    <route id="forcephone.config" path="/admin/module/forcephone/configure" methods="post">
+        <default key="_controller">ForcePhone\Controller\ConfigureController::configure</default>
+    </route>
 </routes>

--- a/Constraints/AtLeastOnePhone.php
+++ b/Constraints/AtLeastOnePhone.php
@@ -1,0 +1,19 @@
+<?php
+/*************************************************************************************/
+/*      This file is part of the Thelia package.                                     */
+/*                                                                                   */
+/*      Copyright (c) OpenStudio                                                     */
+/*      email : dev@thelia.net                                                       */
+/*      web : http://www.thelia.net                                                  */
+/*                                                                                   */
+/*      For the full copyright and license information, please view the LICENSE.txt  */
+/*      file that was distributed with this source code.                             */
+/*************************************************************************************/
+
+namespace ForcePhone\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+
+class AtLeastOnePhone extends Constraint
+{
+}

--- a/Constraints/AtLeastOnePhoneValidator.php
+++ b/Constraints/AtLeastOnePhoneValidator.php
@@ -20,7 +20,7 @@ use Thelia\Core\Translation\Translator;
 class AtLeastOnePhoneValidator extends ConstraintValidator
 {
     /**
-     * Checks if the passed value is valid.
+     * Checks if at least one phone number is provided
      *
      * @param mixed $value The value that should be validated
      * @param Constraint $constraint The constraint for the validation

--- a/Constraints/AtLeastOnePhoneValidator.php
+++ b/Constraints/AtLeastOnePhoneValidator.php
@@ -1,0 +1,41 @@
+<?php
+/*************************************************************************************/
+/*      This file is part of the Thelia package.                                     */
+/*                                                                                   */
+/*      Copyright (c) OpenStudio                                                     */
+/*      email : dev@thelia.net                                                       */
+/*      web : http://www.thelia.net                                                  */
+/*                                                                                   */
+/*      For the full copyright and license information, please view the LICENSE.txt  */
+/*      file that was distributed with this source code.                             */
+/*************************************************************************************/
+
+namespace ForcePhone\Constraints;
+
+use ForcePhone\ForcePhone;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+use Thelia\Core\Translation\Translator;
+
+class AtLeastOnePhoneValidator extends ConstraintValidator
+{
+    /**
+     * Checks if the passed value is valid.
+     *
+     * @param mixed $value The value that should be validated
+     * @param Constraint $constraint The constraint for the validation
+     *
+     * @api
+     */
+    public function validate($value, Constraint $constraint)
+    {
+        $data = $this->context->getRoot()->getData();
+
+        if (empty($data["phone"]) && empty($data["cellphone"])) {
+            $this->context->addViolationAt(
+                "phone",
+                Translator::getInstance()->trans("Please enter at least one phone number.", [], ForcePhone::DOMAIN_NAME)
+            );
+        }
+    }
+}

--- a/Controller/ConfigureController.php
+++ b/Controller/ConfigureController.php
@@ -1,0 +1,87 @@
+<?php
+/*************************************************************************************/
+/*      This file is part of the Thelia package.                                     */
+/*                                                                                   */
+/*      Copyright (c) OpenStudio                                                     */
+/*      email : dev@thelia.net                                                       */
+/*      web : http://www.thelia.net                                                  */
+/*                                                                                   */
+/*      For the full copyright and license information, please view the LICENSE.txt  */
+/*      file that was distributed with this source code.                             */
+/*************************************************************************************/
+
+namespace ForcePhone\Controller;
+
+use ForcePhone\ForcePhone;
+use Thelia\Controller\Admin\BaseAdminController;
+use Thelia\Core\Security\AccessManager;
+use Thelia\Core\Security\Resource\AdminResources;
+use Thelia\Core\Thelia;
+use Thelia\Form\Exception\FormValidationException;
+use Thelia\Tools\URL;
+use Thelia\Tools\Version\Version;
+
+class ConfigureController extends BaseAdminController
+{
+    public function configure()
+    {
+        if (null !== $response = $this->checkAuth(AdminResources::MODULE, 'forcephone', AccessManager::UPDATE)) {
+            return $response;
+        }
+
+        $configurationForm = $this->createForm('forcephone_configuration');
+
+        $message = null;
+
+        try {
+            $form = $this->validateForm($configurationForm);
+
+            // Get the form field values
+            $data = $form->getData();
+
+            foreach ($data as $name => $value) {
+                if (is_array($value)) {
+                    $value = implode(';', $value);
+                }
+
+                ForcePhone::setConfigValue($name, $value);
+            }
+
+            // Log configuration modification
+            $this->adminLogAppend(
+                "forcephone.configuration.message",
+                AccessManager::UPDATE,
+                "ForcePhone configuration updated"
+            );
+
+            // Redirect to the success URL,
+            if ($this->getRequest()->get('save_mode') == 'stay') {
+                // If we have to stay on the same page, redisplay the configuration page/
+                $url = '/admin/module/ForcePhone';
+            } else {
+                // If we have to close the page, go back to the module back-office page.
+                $url = '/admin/modules';
+            }
+
+            return $this->generateRedirect(URL::getInstance()->absoluteUrl($url));
+        } catch (FormValidationException $ex) {
+            $message = $this->createStandardFormValidationErrorMessage($ex);
+        } catch (\Exception $ex) {
+            $message = $ex->getMessage();
+        }
+
+        $this->setupFormErrorContext(
+            $this->getTranslator()->trans("ForcePhone configuration", [], ForcePhone::DOMAIN_NAME),
+            $message,
+            $configurationForm,
+            $ex
+        );
+
+        // Before 2.2, the errored form is not stored in session
+        if (Version::test(Thelia::THELIA_VERSION, '2.2', false, "<")) {
+            return $this->render('module-configure', [ 'module_code' => 'ForcePhone' ]);
+        } else {
+            return $this->generateRedirect(URL::getInstance()->absoluteUrl('/admin/module/ForcePhone'));
+        }
+    }
+}

--- a/EventListeners/ForcePhoneEventListener.php
+++ b/EventListeners/ForcePhoneEventListener.php
@@ -1,7 +1,18 @@
 <?php
+/*************************************************************************************/
+/*      This file is part of the Thelia package.                                     */
+/*                                                                                   */
+/*      Copyright (c) OpenStudio                                                     */
+/*      email : dev@thelia.net                                                       */
+/*      web : http://www.thelia.net                                                  */
+/*                                                                                   */
+/*      For the full copyright and license information, please view the LICENSE.txt  */
+/*      file that was distributed with this source code.                             */
+/*************************************************************************************/
 
 namespace ForcePhone\EventListeners;
 
+use ForcePhone\ForcePhone;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Thelia\Core\Event\TheliaEvents;
 use Thelia\Core\Event\TheliaFormEvent;
@@ -34,15 +45,35 @@ class ForcePhoneEventListener implements EventSubscriberInterface
     public function forcePhoneInput(TheliaFormEvent $event)
     {
         if ($this->request->fromApi() === false) {
-            $event->getForm()->getFormBuilder()
-                ->remove('phone')
-                ->add("phone", "text", array(
-                    "label" => Translator::getInstance()->trans("Phone"),
-                    "label_attr" => array(
-                        "for" => "phone",
-                    ),
-                    "required" => true,
-                ));
+            if (ForcePhone::getConfigValue('force_phone', false)) {
+                $event->getForm()->getFormBuilder()
+                    ->remove('phone')
+                    ->add(
+                        "phone",
+                        "text",
+                        [
+                            "label"      => Translator::getInstance()->trans("Phone"),
+                            "label_attr" => [ "for" => "phone" ],
+                            "required"   => true,
+                        ]
+                    )
+                ;
+            }
+
+            if (ForcePhone::getConfigValue('force_cellphone', false)) {
+                $event->getForm()->getFormBuilder()
+                    ->remove('cellphone')
+                    ->add(
+                        "cellphone",
+                        "text",
+                        [
+                            "label"      => Translator::getInstance()->trans("Cellphone"),
+                            "label_attr" => [ "for" => "cellphone" ],
+                            "required"   => true,
+                        ]
+                    )
+                ;
+            }
         }
     }
 }

--- a/ForcePhone.php
+++ b/ForcePhone.php
@@ -12,6 +12,7 @@
 
 namespace ForcePhone;
 
+use Propel\Runtime\Connection\ConnectionInterface;
 use Thelia\Module\BaseModule;
 
 /**
@@ -23,4 +24,13 @@ class ForcePhone extends BaseModule
 {
     /** @var string */
     const DOMAIN_NAME = 'forcephone';
+
+
+    public function postActivation(ConnectionInterface $con = null)
+    {
+        // Define default values
+        if (null === self::getConfigValue('force_phone', null)) {
+            self::setConfigValue('force_phone', 1);
+        }
+    }
 }

--- a/Form/ConfigForm.php
+++ b/Form/ConfigForm.php
@@ -1,0 +1,56 @@
+<?php
+/*************************************************************************************/
+/*      This file is part of the Thelia package.                                     */
+/*                                                                                   */
+/*      Copyright (c) OpenStudio                                                     */
+/*      email : dev@thelia.net                                                       */
+/*      web : http://www.thelia.net                                                  */
+/*                                                                                   */
+/*      For the full copyright and license information, please view the LICENSE.txt  */
+/*      file that was distributed with this source code.                             */
+/*************************************************************************************/
+
+namespace ForcePhone\Form;
+
+use ForcePhone\ForcePhone;
+use Symfony\Component\Validator\Constraints\NotBlank;
+use Thelia\Form\BaseForm;
+
+class ConfigForm extends BaseForm
+{
+    protected function buildForm()
+    {
+        $this->formBuilder
+            ->add(
+                'force_phone',
+                'checkbox',
+                [
+                    'required' => false,
+                    'label' => $this->translator->trans('Home phone number', [], ForcePhone::DOMAIN_NAME),
+                    'label_attr' => [
+                        'for' => 'force_phone',
+                    ]
+                ]
+            )
+            ->add(
+                'force_cellphone',
+                'checkbox',
+                [
+                    'required' => false,
+                    'label' => $this->translator->trans('Mobile phone number', [], ForcePhone::DOMAIN_NAME),
+                    'label_attr' => [
+                        'for' => 'force_cellphone',
+                    ]
+                ]
+            )
+        ;
+    }
+
+    /**
+     * @return string the name of you form. This name must be unique
+     */
+    public function getName()
+    {
+        return 'forcephone_config';
+    }
+}

--- a/Form/ConfigForm.php
+++ b/Form/ConfigForm.php
@@ -43,6 +43,17 @@ class ConfigForm extends BaseForm
                     ]
                 ]
             )
+            ->add(
+                'force_one',
+                'checkbox',
+                [
+                    'required' => false,
+                    'label' => $this->translator->trans('At least one phone number', [], ForcePhone::DOMAIN_NAME),
+                    'label_attr' => [
+                        'for' => 'force_one',
+                    ]
+                ]
+            )
         ;
     }
 

--- a/Hook/HookManager.php
+++ b/Hook/HookManager.php
@@ -1,0 +1,49 @@
+<?php
+/*************************************************************************************/
+/*                                                                                   */
+/*      Thelia	                                                                     */
+/*                                                                                   */
+/*      Copyright (c) OpenStudio                                                     */
+/*      email : info@thelia.net                                                      */
+/*      web : http://www.thelia.net                                                  */
+/*                                                                                   */
+/*      This program is free software; you can redistribute it and/or modify         */
+/*      it under the terms of the GNU General Public License as published by         */
+/*      the Free Software Foundation; either version 3 of the License                */
+/*                                                                                   */
+/*      This program is distributed in the hope that it will be useful,              */
+/*      but WITHOUT ANY WARRANTY; without even the implied warranty of               */
+/*      MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the                */
+/*      GNU General Public License for more details.                                 */
+/*                                                                                   */
+/*      You should have received a copy of the GNU General Public License            */
+/*	    along with this program. If not, see <http://www.gnu.org/licenses/>.         */
+/*                                                                                   */
+/*************************************************************************************/
+
+namespace ForcePhone\Hook;
+
+use ForcePhone\ForcePhone;
+use Thelia\Core\Event\Hook\HookRenderEvent;
+use Thelia\Core\Hook\BaseHook;
+use Thelia\Model\ModuleConfig;
+use Thelia\Model\ModuleConfigQuery;
+
+class HookManager extends BaseHook
+{
+    public function onModuleConfigure(HookRenderEvent $event)
+    {
+        $vars = [];
+
+        if (null !== $params = ModuleConfigQuery::create()->findByModuleId(ForcePhone::getModuleId())) {
+            /** @var ModuleConfig $param */
+            foreach ($params as $param) {
+                $vars[ $param->getName() ] = $param->getValue();
+            }
+        }
+
+        $event->add(
+            $this->render('force-phone/module-configuration.html', $vars)
+        );
+    }
+}

--- a/I18n/backOffice/default/en_US.php
+++ b/I18n/backOffice/default/en_US.php
@@ -1,0 +1,6 @@
+<?php
+
+return array(
+    'Force Phone Configuration' => 'Force Phone Configuration',
+    'Please check below the phone numbers that must be mandatory in the customer and addresses forms' => 'Please check below the phone numbers that will be required in the customer and address forms',
+);

--- a/I18n/backOffice/default/fr_FR.php
+++ b/I18n/backOffice/default/fr_FR.php
@@ -1,0 +1,6 @@
+<?php
+
+return array(
+    'Force Phone Configuration' => 'Configuration de Force Phone',
+    'Please check below the phone numbers that must be mandatory in the customer and addresses forms' => 'Merci de cocher ci-dessous les numéros de téléphones qui doivent être obligatoirement saisis dans les formulaires client et addresse',
+);

--- a/I18n/en_US.php
+++ b/I18n/en_US.php
@@ -1,5 +1,9 @@
 <?php
 
 return array(
+    'Cellphone' => 'Cellphone',
+    'ForcePhone configuration' => 'ForcePhone configuration',
+    'Home phone number' => 'Home phone number',
+    'Mobile phone number' => 'Mobile phone number',
     'Phone' => 'Phone',
 );

--- a/I18n/en_US.php
+++ b/I18n/en_US.php
@@ -1,9 +1,12 @@
 <?php
 
 return array(
+    'At least one phone number' => 'At least one phone number',
     'Cellphone' => 'Cellphone',
     'ForcePhone configuration' => 'ForcePhone configuration',
     'Home phone number' => 'Home phone number',
     'Mobile phone number' => 'Mobile phone number',
     'Phone' => 'Phone',
+    'Please enter a home or mobile phone number' => 'Please enter a home or mobile phone number',
+    'Please enter at least one phone number.' => 'Please enter at least one phone number.',
 );

--- a/I18n/fr_FR.php
+++ b/I18n/fr_FR.php
@@ -1,9 +1,12 @@
 <?php
 
 return array(
+    'At least one phone number' => 'Au moins un des deux',
     'Cellphone' => 'Téléphone mobile',
     'ForcePhone configuration' => 'Configuration de Force Phone',
     'Home phone number' => 'Numéro de téléphone fixe',
     'Mobile phone number' => 'Numéro de téléphone mobile',
     'Phone' => 'Téléphone fixe',
+    'Please enter a home or mobile phone number' => 'Merci d\'indiquer un numéro de téléphone fixe ou mobile',
+    'Please enter at least one phone number.' => 'Merci d\'indiquer au moins un numéro de téléphone',
 );

--- a/I18n/fr_FR.php
+++ b/I18n/fr_FR.php
@@ -1,5 +1,9 @@
 <?php
 
 return array(
-    'Phone' => 'Téléphone',
+    'Cellphone' => 'Téléphone mobile',
+    'ForcePhone configuration' => 'Configuration de Force Phone',
+    'Home phone number' => 'Numéro de téléphone fixe',
+    'Mobile phone number' => 'Numéro de téléphone mobile',
+    'Phone' => 'Téléphone fixe',
 );

--- a/Readme.md
+++ b/Readme.md
@@ -1,6 +1,6 @@
 # Force Phone
 
-Set phone input as mandatory for customers
+This module sets the mobile phone number, the home phone nuumner or both as required in the customer and address forms.
 
 ## Installation
 
@@ -19,7 +19,8 @@ composer require thelia/force-phone-module:~1.0
 
 ## Usage
 
-Just activate the module and the first phone input will be mandatory.
+Activate the module and the home phone number becomes required in the customer and address forms.
+Go to module configuration to select which phone numbers should be required.
 
 Affected pages :
 - register
@@ -28,7 +29,7 @@ Affected pages :
 
 ## Other
 
-Be sure to set good translations on phone inputs' labels.
+Be sure to set proper translations for phone inputs' labels.
 
 You can find translation for the mandatory input in your administration panel:
 ` Configuration --> Translation --> Modules --> Set the phone input mandatory for the customer --> Core files `

--- a/Readme.md
+++ b/Readme.md
@@ -1,6 +1,6 @@
 # Force Phone
 
-This module sets the mobile phone number, the home phone nuumner or both as required in the customer and address forms.
+This module sets the mobile phone number, the home phone number or both as required in the customer and address forms.
 
 ## Installation
 
@@ -20,7 +20,7 @@ composer require thelia/force-phone-module:~1.0
 ## Usage
 
 Activate the module and the home phone number becomes required in the customer and address forms.
-Go to module configuration to select which phone numbers should be required.
+Go to module configuration to select which phone numbers (home, mobile or both) should be required.
 
 Affected pages :
 - register

--- a/Readme.md
+++ b/Readme.md
@@ -1,6 +1,6 @@
 # Force Phone
 
-This module sets the mobile phone number, the home phone number or both as required in the customer and address forms.
+This module sets the mobile phone number, the home phone number, both or one of them as required in the customer and address forms.
 
 ## Installation
 
@@ -20,7 +20,7 @@ composer require thelia/force-phone-module:~1.0
 ## Usage
 
 Activate the module and the home phone number becomes required in the customer and address forms.
-Go to module configuration to select which phone numbers (home, mobile or both) should be required.
+Go to module configuration to select which phone numbers (home, mobile, both or one of them) should be required.
 
 Affected pages :
 - register

--- a/templates/backOffice/default/force-phone/module-configuration.html
+++ b/templates/backOffice/default/force-phone/module-configuration.html
@@ -1,0 +1,50 @@
+<div class="row">
+    <div class="col-md-12 general-block-decorator">
+        <div class="row">
+            <div class="col-md-12 title title-without-tabs">
+                {intl d='forcephone.bo.default' l="Force Phone Configuration"}
+            </div>
+        </div>
+
+        <div class="form-container">
+            <div class="row">
+                <div class="col-md-12">
+                    {form name="forcephone_configuration"}
+                        <form action="{url path="/admin/module/forcephone/configure"}" method="post">
+                            {form_hidden_fields form=$form}
+
+                            {include file = "includes/inner-form-toolbar.html"
+                                hide_flags = true
+                                page_url   = "{url path='/admin/module/ForcePhone'}"
+                                close_url  = "{url path='/admin/modules'}"
+                            }
+
+                            {if $form_error}
+                                <div class="row">
+                                    <div class="col-md-12">
+                                        <div class="alert alert-danger">{$form_error_message}</div>
+                                    </div>
+                                </div>
+                            {/if}
+
+                            <div class="row">
+                                <div class="col-md-12">
+                                    <p>{intl d='forcephone.bo.default' l='Please check below the phone numbers that must be mandatory in the customer and addresses forms'}</p>
+                                    {custom_render_form_field form=$form field="force_phone"}
+                                        <input type="checkbox" {form_field_attributes form=$form field="force_phone"} {if $force_phone}checked{/if}>
+                                        {$label}
+                                    {/custom_render_form_field}
+
+                                    {custom_render_form_field form=$form field="force_cellphone"}
+                                        <input type="checkbox" {form_field_attributes form=$form field="force_cellphone"} {if $force_cellphone}checked{/if}>
+                                    {$label}
+                                    {/custom_render_form_field}
+                                </div>
+                            </div>
+                        </form>
+                    {/form}
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/templates/backOffice/default/force-phone/module-configuration.html
+++ b/templates/backOffice/default/force-phone/module-configuration.html
@@ -39,6 +39,11 @@
                                         <input type="checkbox" {form_field_attributes form=$form field="force_cellphone"} {if $force_cellphone}checked{/if}>
                                     {$label}
                                     {/custom_render_form_field}
+
+                                    {custom_render_form_field form=$form field="force_one"}
+                                        <input type="checkbox" {form_field_attributes form=$form field="force_one"} {if $force_one}checked{/if}>
+                                    {$label}
+                                    {/custom_render_form_field}
                                 </div>
                             </div>
                         </form>


### PR DESCRIPTION
The module supports now the following features : 
- home phone number required
- mobile phone number required 
- both required
- at least one required
- none required

A configuration page has been created to allow administrator to select which phone numbers are required in the customer and address forms.
